### PR TITLE
Fixes crashing Global, adds .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,62 @@
+
+# Godot-specific ignores
+.import/
+export.cfg
+export_presets.cfg
+*.import
+
+# Mono-specific ignores
+.mono/
+data_*/
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk

--- a/Game.tscn
+++ b/Game.tscn
@@ -218,6 +218,7 @@ stream = ExtResource( 13 )
 stream = ExtResource( 14 )
 
 [node name="HUD" type="Control" parent="."]
+visible = false
 margin_right = 40.0
 margin_bottom = 40.0
 script = ExtResource( 4 )

--- a/HUD/Global.gd
+++ b/HUD/Global.gd
@@ -1,10 +1,9 @@
 extends Node
 
-onready var HUD = get_node("/root/Game/HUD")
-onready var Camera1 = get_node("/root/Game/Camera")
-onready var Camera2 = get_node("/root/Game/HUD/Camera")
-onready var WE = get_node("/root/Game/WorldEnvironment")
-
+var HUD = null
+var Camera1 = null
+var Camera2 = null
+var WE = null
 
 
 
@@ -12,7 +11,12 @@ onready var WE = get_node("/root/Game/WorldEnvironment")
 
 
 func _process(_delta):
-	if Input.is_action_just_pressed("menu"):	
+	if HUD == null:
+		HUD = get_node_or_null("/root/Game/HUD")		
+		Camera1 = get_node_or_null("/root/Game/Camera")
+		Camera2 = get_node_or_null("/root/Game/HUD/Camera")
+		WE = get_node_or_null("/root/Game/WorldEnvironment")
+	if HUD != null and Input.is_action_just_pressed("menu"):	
 		if HUD.visible:
 			HUD.hide()
 			Camera2.current = false

--- a/Menu/Menu.gd
+++ b/Menu/Menu.gd
@@ -1,7 +1,7 @@
 extends Control
 
 func _on_Play_pressed():
-   get_tree().change_scene("res://Game.tscn")
+	var _scene = get_tree().change_scene("res://Game.tscn")
 
 
 


### PR DESCRIPTION
The problem was that the Global script assumes that some nodes exist when it first starts; you interrupted that by creating the main menu scene. I changed Global so it loads them as soon as they are ready; hopefully that helps.

I also hid the menu when the main scene loads, in case you are wondering where that went.